### PR TITLE
Get it compiling on Linux.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,9 +27,9 @@ CC	= gcc
 CXX	= g++
 LD	= g++
 STRIP	= strip
-#CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) $(GLUI_INCS) $(FTGL_INCS) -O2 -mtune=athlon-xp -ffast-math -funroll-loops -m3dnow -mmmx -msse -msse2 #-mfpmath=sse #-fomit-frame-pointer
-CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) $(GLUI_INCS) $(FTGL_INCS) -O1 -ffast-math -m3dnow -mmmx -msse -msse2
-LDFLAGS	= -g -rdynamic -lGL -lGLU -lGLEW -L/usr/X11R6/lib $(GLUI_LIBS) $(FTGL_LIBS) `sdl-config --libs` -lz
+#CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) -O2 -mtune=athlon-xp -ffast-math -funroll-loops -m3dnow -mmmx -msse -msse2 #-mfpmath=sse #-fomit-frame-pointer
+CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) -O1 -ffast-math -m3dnow -mmmx -msse -msse2
+LDFLAGS	= -g -rdynamic -lGL -lGLU -lGLEW -L/usr/X11R6/lib `sdl-config --libs` -lz
 DLFLAGS = -shared -Wl,-Bsymbolic
 O	= o
 COUT	= -c -o #
@@ -142,7 +142,7 @@ TARGET3 = tester
 TARGET3LD = -ldl
 TARGET4 = z64gl.so
 TARGET5 = zbench64
-TARGET4LD = -lGLEW -lIL
+TARGET4LD = -lGLEW
 else
 TARGET	= z64.dll
 TARGET2	= z64-rsp.dll
@@ -156,7 +156,9 @@ TARGET5LD = -lglew32 $(SDL_LIB)
 endif
 
 ifeq ("$(RDP_DEBUG)", "1")
-CFLAGS += -DRDP_DEBUG
+CFLAGS += $(GLUI_INCS) $(FTGL_INCS) -DRDP_DEBUG
+LDFLAGS += $(GLUI_LIBS) $(FTGL_LIBS)
+TARGET4LD += -lIL
 endif
 
 all: $(TARGET) $(TARGET2) $(TARGET3) $(TARGET4) $(TARGET5) instruction

--- a/src/rdp.h
+++ b/src/rdp.h
@@ -251,7 +251,14 @@ static void FATAL(const char * s, ...)
   va_end(ap);
   exit(0);
 }
-#ifndef WIN32
+
+#if 0 && !defined(WIN32)
+/*
+ * RDP_DEBUG entails other dependencies like GLUT, GLUI and IL.
+ *
+ * The `Makefile' environment should be responsible for #define'ing this,
+ * but here is the place and time to force otherwise if preferred.
+ */
 #define RDP_DEBUG
 #endif
 


### PR DESCRIPTION
Now I'm no `Makefile` expert, but it seems that ziggy threw in custom directory paths to his own hard drive contents for things like GLUI and made the Linux build of `z64gl.so` default to linking those dependencies in.

I find this problematic because a) I am not interested in debug GUI builds of the plugin and b) GLUI and devIL are not available on my distribution out-of-the-box, and I don't feel like installing them.
