### PR TITLE
Clean all object files, not just TARGET1.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -201,7 +201,7 @@ instruction:
 	$(warning please copy $(TARGET2) and $(TARGET4) in the plugins/ folder of the emulator)
 
 clean:
-	rm -rf $(OBJECTS) $(ALL)
+	rm -rf $(OBJECTS) $(OBJECTS2) $(OBJECTS3) $(OBJECTS4) $(OBJECTS5) $(ALL)
 
 rebuild: clean $(ALL)
 


### PR DESCRIPTION
`make clean` and `make rebuild` are not working.

They only clear the files used by the original SDL z64 plugin, not the entire OpenGL z64gl version, the z64 RSP or any of the other linker objects generated.  Therefore, if I want to change a compile flag to rebuild the entire solution, I have to delete all the .o files manually because `make clean` won't delete them all and let me test re-compiling with the new configuration.  This commit fixes that.
