### PR TITLE
Fix 64-bit linkage on non-WIN32 with -fPIC.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -94,6 +94,11 @@ LOUT	= -o #
 endif
 endif
 
+LBITS := $(shell getconf LONG_BIT)
+ifeq ($(LBITS),64)
+CFLAGS += -fPIC
+endif
+
 ifeq ("$(RGL_ASSERT)", "1")
 CFLAGS	+= -DRGL_ASSERT
 endif


### PR DESCRIPTION
PIC linkage is needed for 64-bit builds of shared objects like dynamically linked Windows libraries.

Maybe on WIN64 -fPIC can be omitted and still succeed under MinGW-w64, but IIRC this flag is treated as a dummy option when PIC is not really required anyway on that environment.
