### PR TITLE
Don't track link results or their derived files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
+# Makefile target 1:  z64 (MAME software port)
+z64.dll
+z64.so
+
+# Makefile target 2:  MAME RSP interpreter core (plugin port)
+z64-rsp.dll
+z64-rsp.so
+
+# Makefile target 3:  GBI microcode tester
+tester.exe
+tester
+
+# Makefile target 4:  z64 (OpenGL-accelerated branch)
+z64gl.dll
+z64gl.so
+
+# Makefile target 5:  GLSL and profiling
+zbench64
+zbench64log.txt
+zbench64err.txt
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
Really the only reason I started this branch is that `zbench64`, `tester` and `zbench64log.txt` all show up in the status of the current Git working tracking tree after successfully doing a `make all` in the shell.

Some of it is slight re-specification I suppose (what with the *.dll and *.so extensions already added to the .gitignore), but if that's extraneous documentation I can just remove that and leave the extra files that aren't getting filtered.
