### PR TITLE
Get it playing under 64-bit Linux.

### DIFF
--- a/src/winlnxdefs.h
+++ b/src/winlnxdefs.h
@@ -12,9 +12,9 @@ typedef long long LONGLONG;
 typedef int __int32;
 
 typedef void* HINSTANCE;
+typedef void* HWND;
 typedef int PROPSHEETHEADER;
 typedef int PROPSHEETPAGE;
-typedef int HWND;
 
 #define FALSE false
 #define TRUE true


### PR DESCRIPTION
I was rather slow to remember that the same reason why z64 and z64gl did not work on 64-bit was for the same exact reason as what I had to fix with Mupen64:  `"winlnxdefs.h"`, which mistranscribes zilmar's usage of HWND as `int` instead of a pointer.

Because `sizeof(void*) > sizeof(int)` on LP64 ABI implementations, this caused a lack of memory transparency between the GFX_INFO struct binary sent by the emulator core versus that received by the plugins, effectively offsetting the pointers and memory alignments and positions of all of the VI registers and totally breaking emulation.

Both plugins and the core need to agree on a common definition for HWND.  My vote goes to either `long` or some kind of pointer, like `void*`.
