### PR TITLE
Disable constant console buffer spamming from z64.

### DIFF
--- a/src/rdp-mess.cpp
+++ b/src/rdp-mess.cpp
@@ -2987,7 +2987,10 @@ static void rdp_sync_full(UINT32 w1, UINT32 w2)
 {
   // VP ?
 	//dp_full_sync();
+
+#if defined(_DEBUG)
   printf("full sync\n");
+#endif
   rdp_update();
 
   *gfx.MI_INTR_REG |= 0x20;


### PR DESCRIPTION
I don't know whose idea it was to constantly `printf` to the console buffer every single time a `DP_SYNC_FULL` command is executed, but it's causing me to not be able to debug Mupen64's console output with a game as conventional as Mario64, due to it being flooded with repeated lines of the same "full sync" text.

Not that z64 is the module of interest here in this repository:  z64gl is.  Still, I use z64 to test.
