### PR TITLE
Track the official z64gl configuration file.

### DIFF
--- a/z64gl.conf
+++ b/z64gl.conf
@@ -1,0 +1,120 @@
+############################################################################
+#
+# Z64 configuration file
+#
+# This config file is organized in three parts :
+#  - first part are default values for all games
+#  - second part are settings that you can specify for specific roms
+#  - third part allow you to override settings from second part globally
+#
+# Lines starting with a "#" are comments
+#
+############################################################################
+
+############################################################################
+# 1) global settings
+############################################################################
+
+# windowed resolution
+res_x = 1024
+res_y = 768
+
+# fullscreen resolution
+fs_res_x = 1024
+fs_res_y = 768
+
+hires_fb = 1
+force_swap = 0
+
+# try to set this to 1 if the plugin crashes (necessary on geforce 5900 for example)
+no_npot_fbos = 0
+
+# try this option with mupen, it might make z64 a bit unstable though
+# games that benefit from this option : 
+# Banjo & Kazoie, Mario Kart, Zelda MM, Zelda OOT and probably others
+fb_info = 0
+
+# if 1 then use original N64 screen resolution
+# can give good results on 2d games that show bad texels mapping
+# (for example Mischief Makers and Nintama Rantarou Gallery)
+lowres = 0
+
+# run RDP emulator in a separate thread
+# REQUIRED with Pj64 1.6 and below (not with 1.7), or along with the "async" option
+threaded = 0
+
+# emulate RDP asynchronously, might be faster, needs "threaded = 1" option
+# a bit unstable, also fb_info is currently forced to off then
+async = 0
+
+############################################################################
+# 2) per rom settings
+############################################################################
+[ZELDA MAJORA'S MASK]
+fb_info = 1
+
+[MAJORA'S MASK]
+fb_info = 1
+
+[Banjo-Kazooie]
+# cause freeze when entering a level
+#fb_info = 1
+
+[BANJO KAZOOIE 2]
+#fb_info = 1
+
+[BANJO TOOIE]
+fb_info = 1
+
+[MARIOKART64]
+fb_info = 1
+
+[ZELDA MASTER QUEST]
+fb_info = 1
+
+[THE LEGEND OF ZELDA]
+fb_info = 1
+
+[Beetle Adventure Rac]
+fb_info = 1
+
+[Stunt Racer 64]
+force_swap = 1
+
+[Perfect Dark]
+fb_info = 1
+force_swap = 1
+
+[Resident Evil II]
+fb_info = 1
+#force_swap = 1
+
+[rogue squadron]
+#fb_info = 1
+#force_swap = 1
+
+[Battle for Naboo]
+force_swap = 1
+
+[MarioGolf64]
+fb_info = 1
+
+[Blast Corps]
+force_swap = 1
+
+[MISCHIEF MAKERS]
+lowres = 1
+
+[NINTAMAGAMEGALLERY64]
+lowres = 1
+
+[PUYOPUYO4]
+lowres = 1
+
+############################################################################
+# 3) override settings
+############################################################################
+# this section should be last, it allows to override options set per rom
+# (for example if you want to force lowres to 0 for all games, put it here)
+[override]
+#fb_info = 0


### PR DESCRIPTION
I was not able to obtain this file from anywhere without extracting the contents of ziggy's Win32 binary release zip.  It is not a part of the source code to z64gl in and of its self, but I think that as another piece of text information affecting the plugin's behavior during emulation it could be useful to track any potential future changes via Git, if not just to have the download ready for non-Windows users.

I have it placed outside of the `src/` subdirectory of the repository to avoid clashing with the source.
