### PR TITLE
Fix RDP command buffer overflow & memory leak causing #12.

### DIFF
--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -775,9 +775,13 @@ void rdp_process_list(void)
     memcpy(rdpTraceBuf+rdpTracePos, rdp_cmd_data+rdp_cmd_cur, rdp_command_length[cmd]);
 #endif
 
-    if (rdp_cmd_cur + rdp_command_length[cmd]/4 > MAXCMD)
-      memcpy(rdp_cmd_data + MAXCMD, rdp_cmd_data, rdp_command_length[cmd] - (MAXCMD - rdp_cmd_cur)*4);
-    
+    if (rdp_cmd_cur + rdp_command_length[cmd]/4 > MAXCMD) {
+        size_t copy_length;
+
+        copy_length = rdp_command_length[cmd] - 4*(MAXCMD - rdp_cmd_cur);
+        memcpy(&rdp_cmd_data[MAXCMD], &rdp_cmd_data[0], copy_length);
+    }
+
 		// execute the command
 		rdp_command_table[cmd](rdp_cmd_data[rdp_cmd_cur+0], rdp_cmd_data[rdp_cmd_cur+1]);
 

--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -54,8 +54,9 @@ static int nbTmemAreas;
 int rdp_dump;
 #endif
 
-#define MAXCMD 0x100000
-static uint32_t rdp_cmd_data[MAXCMD+32];
+#define MAXCMD                  0x100000
+#define CMD_OVERFLOW_RESERVE    32
+static uint32_t rdp_cmd_data[MAXCMD + CMD_OVERFLOW_RESERVE];
 static volatile int rdp_cmd_ptr = 0;
 static volatile int rdp_cmd_cur = 0;
 static int rdp_cmd_left = 0;
@@ -777,8 +778,16 @@ void rdp_process_list(void)
 
     if (rdp_cmd_cur + rdp_command_length[cmd]/4 > MAXCMD) {
         size_t copy_length;
+        const size_t limit = CMD_OVERFLOW_RESERVE * sizeof(rdp_cmd_data[0]);
 
         copy_length = rdp_command_length[cmd] - 4*(MAXCMD - rdp_cmd_cur);
+        if (copy_length > limit) {
+            fprintf(stderr,
+                "ERROR:  rdp_cmd_data[0x%X] overflow (%lu > %lu)\n",
+                MAXCMD, copy_length, limit
+            );
+            copy_length = limit;
+        }
         memcpy(&rdp_cmd_data[MAXCMD], &rdp_cmd_data[0], copy_length);
     }
 


### PR DESCRIPTION
This is not a proper fix to https://github.com/purplemarshmallow/z64/issues/12, but it cleans up the code syntax of the faulty part of the code, adds diagnostics for future debugging, and does certainly fix all the crashing I have had here.

The temporary fix is that if the command overflow boundary exceeds the scratch memory (32 MIPS words), clamp it to the maximum to prevent overstepping memory bounds.

The real fix is to remove the MAXCMD limit totally.  angrylion's new code documents one of the ways to fix this, but atm I have just implemented a quick fix and diagnostic to emphasize the problem.

If you had no crashing before this pull request... it was because the bug corrupted your memory layout in the emulator differently (in a non-crashy, but still buggy) way than it did with mine.
