### PR TITLE
[zbench64] removed GLEW dependency from optional target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,7 @@ LD	= g++
 STRIP	= strip
 #CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) -O2 -mtune=athlon-xp -ffast-math -funroll-loops -m3dnow -mmmx -msse -msse2 #-mfpmath=sse #-fomit-frame-pointer
 CFLAGS	= -g -DGCC -DUSE_GTK `sdl-config --cflags` $(GTK_FLAGS) -O1 -ffast-math -m3dnow -mmmx -msse -msse2
-LDFLAGS	= -g -rdynamic -lGL -lGLU -lGLEW -L/usr/X11R6/lib `sdl-config --libs` -lz
+LDFLAGS	= -g -rdynamic -lGL -lGLU -L/usr/X11R6/lib `sdl-config --libs` -lz
 DLFLAGS = -shared -Wl,-Bsymbolic
 O	= o
 COUT	= -c -o #
@@ -147,16 +147,16 @@ TARGET3 = tester
 TARGET3LD = -ldl
 TARGET4 = z64gl.so
 TARGET5 = zbench64
-TARGET4LD = -lGLEW
+TARGET4LD = -lGL
 else
 TARGET	= z64.dll
 TARGET2	= z64-rsp.dll
 TARGET3 = tester.exe
 TARGET4 = z64gl.dll
 TARGET5 = zbench64.exe
-TARGET4LD = -lglew32 $(SDL_LIB) # /usr/mingw32/usr/lib/libSDL.a #-lSDL
-#TARGET5LD = -lglew32 /usr/mingw32/usr/lib/libSDL.a  -Dmain=SDL_main -lSDLmain -lmingw32 #-lSDL
-TARGET5LD = -lglew32 $(SDL_LIB)
+TARGET4LD = $(SDL_LIB) # /usr/mingw32/usr/lib/libSDL.a #-lSDL
+#TARGET5LD = /usr/mingw32/usr/lib/libSDL.a  -Dmain=SDL_main -lSDLmain -lmingw32 #-lSDL
+TARGET5LD = $(SDL_LIB)
 #CFLAGS	+=  -Dmain=SDL_main
 endif
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -38,20 +38,37 @@ static __inline__ unsigned long long RDTSC(void)
 
 void renderquad(int nbtex)
 {
-  glBegin(GL_TRIANGLE_STRIP);
-  if (nbtex == 2) glMultiTexCoord2fARB(GL_TEXTURE1_ARB, 0.5, 0);
-  if (nbtex == 3) glMultiTexCoord2fARB(GL_TEXTURE2_ARB, 0.5, 0);
-  glMultiTexCoord2fARB(GL_TEXTURE0_ARB, 1, 0); glVertex3f(1, 0, 0);
-  if (nbtex == 2) glMultiTexCoord2fARB(GL_TEXTURE1_ARB, 0, 0);
-  if (nbtex == 3) glMultiTexCoord2fARB(GL_TEXTURE2_ARB, 0, 0);
-  glMultiTexCoord2fARB(GL_TEXTURE0_ARB, 0, 0); glVertex3f(0, 0, 1);
-  if (nbtex == 2) glMultiTexCoord2fARB(GL_TEXTURE1_ARB, 0.5, 0.5);
-  if (nbtex == 3) glMultiTexCoord2fARB(GL_TEXTURE2_ARB, 0.5, 0.5);
-  glMultiTexCoord2fARB(GL_TEXTURE0_ARB, 1, 1); glVertex3f(1, 1, 1);
-  if (nbtex == 2) glMultiTexCoord2fARB(GL_TEXTURE1_ARB, 0, 0.5);
-  if (nbtex == 3) glMultiTexCoord2fARB(GL_TEXTURE2_ARB, 0, 0.5);
-  glMultiTexCoord2fARB(GL_TEXTURE0_ARB, 0, 1); glVertex3f(0, 1, 0);
-  glEnd();
+    glBegin(GL_TRIANGLE_STRIP);
+
+    if (nbtex == 2)
+        xglMultiTexCoord2f(GL_TEXTURE1_ARB, 0.5, 0);
+    if (nbtex == 3)
+        xglMultiTexCoord2f(GL_TEXTURE2_ARB, 0.5, 0);
+    xglMultiTexCoord2f(GL_TEXTURE0_ARB, 1, 0);
+    glVertex3f(1, 0, 0);
+
+    if (nbtex == 2)
+        xglMultiTexCoord2f(GL_TEXTURE1_ARB, 0, 0);
+    if (nbtex == 3)
+        xglMultiTexCoord2f(GL_TEXTURE2_ARB, 0, 0);
+    xglMultiTexCoord2f(GL_TEXTURE0_ARB, 0, 0);
+    glVertex3f(0, 0, 1);
+
+    if (nbtex == 2)
+        xglMultiTexCoord2f(GL_TEXTURE1_ARB, 0.5, 0.5);
+    if (nbtex == 3)
+        xglMultiTexCoord2f(GL_TEXTURE2_ARB, 0.5, 0.5);
+    xglMultiTexCoord2f(GL_TEXTURE0_ARB, 1, 1);
+    glVertex3f(1, 1, 1);
+
+    if (nbtex == 2)
+        xglMultiTexCoord2f(GL_TEXTURE1_ARB, 0, 0.5);
+    if (nbtex == 3)
+        xglMultiTexCoord2f(GL_TEXTURE2_ARB, 0, 0.5);
+    xglMultiTexCoord2f(GL_TEXTURE0_ARB, 0, 1);
+    glVertex3f(0, 1, 0);
+
+    glEnd();
 }
 
 void test(int num, const char * vsrc, const char * fsrc, int nbtex)
@@ -88,18 +105,19 @@ void test(int num, const char * vsrc, const char * fsrc, int nbtex)
   shader = rglCreateShader(vsrc, src);
 
   rglUseShader(shader);
-  int location;
-  location = glGetUniformLocationARB(shader->prog, "texture0");
-  glUniform1iARB(location, 0);
-  if (nbtex == 2) {
-    location = glGetUniformLocationARB(shader->prog, "texture1");
-    glUniform1iARB(location, 1);
-  }
-  if (nbtex == 3) {
-    location = glGetUniformLocationARB(shader->prog, "texture2");
-    glUniform1iARB(location, 2);
-  }
 
+    int location;
+
+    location = xglGetUniformLocation(shader->prog, "texture0");
+    xglUniform1i(location, 0);
+    if (nbtex == 2) {
+        location = xglGetUniformLocation(shader->prog, "texture1");
+        xglUniform1i(location, 1);
+    }
+    if (nbtex == 3) {
+        location = xglGetUniformLocation(shader->prog, "texture2");
+        xglUniform1i(location, 2);
+    }
 
   glDisable(GL_DEPTH_TEST);
   glViewport(0, 0, screen_width, screen_height);
@@ -119,13 +137,17 @@ void test(int num, const char * vsrc, const char * fsrc, int nbtex)
   fflush(stdout);
 }
 
+static int GL_failed = -1;
 void dobenchmark()
 {
   static char tex[256*256*4];
   int i;
   float env[4];
 
-  glewInit();
+    if (GL_failed < 0) {
+        GL_failed = init_GL_extensions();
+	printf("Errors loading OpenGL extensions:  %i\n", GL_failed);
+    }
 
   glViewport(0, 0, screen_width, screen_height);
 
@@ -299,7 +321,7 @@ void dobenchmark()
   );
 }
 
-int main(int argc, char * * argv)
+int main(int argc, char ** argv)
 {
   printf("main\n");
 
@@ -363,7 +385,7 @@ int main(int argc, char * * argv)
   sprintf(caption, "z64 benchmarker");
   SDL_WM_SetCaption(caption, caption);
 
-  dobenchmark();
+    dobenchmark();
 
   rglUseShader(0);
   SDL_GL_SwapBuffers();

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -162,14 +162,15 @@ void dobenchmark()
     tex[i] = i*7;
   }
   tex[1] = 255;
-  glBindTexture(GL_TEXTURE_2D, 1);
-  glActiveTextureARB(GL_TEXTURE1_ARB);
-  glBindTexture(GL_TEXTURE_2D, 1);
-  glActiveTextureARB(GL_TEXTURE2_ARB);
-  glBindTexture(GL_TEXTURE_2D, 1);
-  glActiveTextureARB(GL_TEXTURE0_ARB);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-	       tex);
+    glBindTexture(GL_TEXTURE_2D, 1);
+    xglActiveTexture(GL_TEXTURE1_ARB);
+    glBindTexture(GL_TEXTURE_2D, 1);
+    xglActiveTexture(GL_TEXTURE2_ARB);
+    glBindTexture(GL_TEXTURE_2D, 1);
+    xglActiveTexture(GL_TEXTURE0_ARB);
+    glTexImage2D(
+        GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE, tex
+    );
   glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
                    GL_LINEAR );
   glTexParameterf( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
@@ -246,9 +247,9 @@ void dobenchmark()
     ,1
   );
 
-  glActiveTextureARB(GL_TEXTURE1_ARB);
-  glTexEnvfv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, env);
-  glActiveTextureARB(GL_TEXTURE0_ARB);
+    xglActiveTexture(GL_TEXTURE1_ARB);
+    glTexEnvfv(GL_TEXTURE_ENV, GL_TEXTURE_ENV_COLOR, env);
+    xglActiveTexture(GL_TEXTURE0_ARB);
   test(4, commonv,
     "  gl_FragColor = gl_TextureEnvColor[1] * texture2D(texture0, vec2(gl_TexCoord[0])); \n"
     ,1


### PR DESCRIPTION
No more with z64gl, but if using the `Makefile` instead of Visual Studio it is possible to see complaints about the tester benchmark application (target 5) failing to compile or link in the absence of GLEW libraries or header API includes.

It did not occur to me to install my custom code replacement for GLEW to this module as well until I noticed that benchmark.cpp gets linked alongside glshader.cpp, which is where I invented my custom routine for extension-loading.  This works out conveniently for removing GLEW from both targets.

You guys should be able to delete this file now  (I am not on Windows so cannot prove it):
https://github.com/purplemarshmallow/z64/blob/master/src/GL/glew32.lib
