### PR TITLE
fixed all basic warnings

### DIFF
--- a/src/rdp-mess.cpp
+++ b/src/rdp-mess.cpp
@@ -1021,7 +1021,7 @@ INLINE void FETCH_TEXEL(COLOR *color, int s, int t, UINT32 twidth, UINT32 tforma
 	}
 }
 
-#if 1
+#if 0
 #define TEXTURE_PIPELINE(TEX, SSS, SST, NOBILINEAR)																					\
 do																																	\
 {																																	\
@@ -1074,12 +1074,11 @@ do																																	\
 	}																																\
 }																																	\
 while(0)
-#endif
 
+#else
 // This is the implementation with 3-sample bilinear filtering, which should be more correct, but not yet working properly
 // TODO: check the correct texel samples and weighting values
 
-#if 1
 #define TEXTURE_PIPELINE(TEX, SSS, SST, NOBILINEAR)																					\
 do																																	\
 {																																	\

--- a/src/rdp-mess.cpp
+++ b/src/rdp-mess.cpp
@@ -25,30 +25,25 @@ inline void fatalerror(const char * err, ...)
 static FILE *rdp_exec;
 #endif
 
-/* defined in systems/n64.c */
-#define rdram ((UINT32*)gfx.RDRAM)
-//extern UINT32 *rdram;
-#define rsp_imem ((UINT32*)gfx.IMEM)
-//extern UINT32 *rsp_imem;
-#define rsp_dmem ((UINT32*)gfx.DMEM)
-//extern UINT32 *rsp_dmem;
-//extern void dp_full_sync(void);
+/*
+ * MAME:  defined in systems/n64.c
+ * zilmar plugins:  #define'd in "Gfx #1.3.h" (Disable the below lines.)
+ */
+#ifndef PLUGIN_TYPE_GFX
+extern UINT32 *rdram;
+extern UINT32 *rsp_imem;
+extern UINT32 *rsp_dmem;
+extern void dp_full_sync(void);
 
-#define vi_origin (*(UINT32*)gfx.VI_ORIGIN_REG)
-//extern UINT32 vi_origin;
-#define vi_width (*(UINT32*)gfx.VI_WIDTH_REG)
-//extern UINT32 vi_width;
-#define vi_control (*(UINT32*)gfx.VI_STATUS_REG)
-//extern UINT32 vi_control;
+extern UINT32 vi_origin;
+extern UINT32 vi_width;
+extern UINT32 vi_control;
 
-#define dp_start (*(UINT32*)gfx.DPC_START_REG)
-//extern UINT32 dp_start;
-#define dp_end (*(UINT32*)gfx.DPC_END_REG)
-//extern UINT32 dp_end;
-#define dp_current (*(UINT32*)gfx.DPC_CURRENT_REG)
-//extern UINT32 dp_current;
-#define dp_status (*(UINT32*)gfx.DPC_STATUS_REG)
-//extern UINT32 dp_status;
+extern UINT32 dp_start;
+extern UINT32 dp_end;
+extern UINT32 dp_current;
+extern UINT32 dp_status;
+#endif
 
 static UINT32 rdp_cmd_data[0x1000];
 static int rdp_cmd_ptr = 0;

--- a/src/tester.cpp
+++ b/src/tester.cpp
@@ -80,6 +80,10 @@ RSP_INFO rspinfo = {
 DWORD (*dorspcycles) ( DWORD Cycles );
 void (*initiatersp) ( RSP_INFO Rsp_Info, DWORD * CycleCount);
 
+#ifdef rsp
+#undef rsp
+/* fixes an unrelated macro re-definition over the one in "rsp.h" */
+#endif
 #define rsp tester_rsp
 RSP_REGS rsp __attribute__((aligned(16)));
 


### PR DESCRIPTION
All of the normal level warnings are fixed by these commits, specifically:

```
rdp-mess.cpp:29:0: warning: "rdram" redefined [enabled by default]
 #define rdram ((UINT32*)gfx.RDRAM)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:116:0: note: this is the location of the previous definition
 #define rdram ((uint32_t*)gfx.RDRAM)
 ^
rdp-mess.cpp:31:0: warning: "rsp_imem" redefined [enabled by default]
 #define rsp_imem ((UINT32*)gfx.IMEM)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:117:0: note: this is the location of the previous definition
 #define rsp_imem ((uint32_t*)gfx.IMEM)
 ^
rdp-mess.cpp:33:0: warning: "rsp_dmem" redefined [enabled by default]
 #define rsp_dmem ((UINT32*)gfx.DMEM)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:118:0: note: this is the location of the previous definition
 #define rsp_dmem ((uint32_t*)gfx.DMEM)
 ^
rdp-mess.cpp:37:0: warning: "vi_origin" redefined [enabled by default]
 #define vi_origin (*(UINT32*)gfx.VI_ORIGIN_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:119:0: note: this is the location of the previous definition
 #define vi_origin (*(uint32_t*)gfx.VI_ORIGIN_REG)
 ^
rdp-mess.cpp:39:0: warning: "vi_width" redefined [enabled by default]
 #define vi_width (*(UINT32*)gfx.VI_WIDTH_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:120:0: note: this is the location of the previous definition
 #define vi_width (*(uint32_t*)gfx.VI_WIDTH_REG)
 ^
rdp-mess.cpp:41:0: warning: "vi_control" redefined [enabled by default]
 #define vi_control (*(UINT32*)gfx.VI_STATUS_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:121:0: note: this is the location of the previous definition
 #define vi_control (*(uint32_t*)gfx.VI_STATUS_REG)
 ^
rdp-mess.cpp:44:0: warning: "dp_start" redefined [enabled by default]
 #define dp_start (*(UINT32*)gfx.DPC_START_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:123:0: note: this is the location of the previous definition
 #define dp_start (*(uint32_t*)gfx.DPC_START_REG)
 ^
rdp-mess.cpp:46:0: warning: "dp_end" redefined [enabled by default]
 #define dp_end (*(UINT32*)gfx.DPC_END_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:124:0: note: this is the location of the previous definition
 #define dp_end (*(uint32_t*)gfx.DPC_END_REG)
 ^
rdp-mess.cpp:48:0: warning: "dp_current" redefined [enabled by default]
 #define dp_current (*(UINT32*)gfx.DPC_CURRENT_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:125:0: note: this is the location of the previous definition
 #define dp_current (*(uint32_t*)gfx.DPC_CURRENT_REG)
 ^
rdp-mess.cpp:50:0: warning: "dp_status" redefined [enabled by default]
 #define dp_status (*(UINT32*)gfx.DPC_STATUS_REG)
 ^
In file included from rdp-mess.cpp:9:0:
Gfx #1.3.h:126:0: note: this is the location of the previous definition
 #define dp_status (*(uint32_t*)gfx.DPC_STATUS_REG)
 ^
rdp-mess.cpp:1083:0: warning: "TEXTURE_PIPELINE" redefined [enabled by default]
 #define TEXTURE_PIPELINE(TEX, SSS, SST, NOBILINEAR)                     \
 ^
rdp-mess.cpp:1025:0: note: this is the location of the previous definition
 #define TEXTURE_PIPELINE(TEX, SSS, SST, NOBILINEAR)                     \
 ^
```

As I go on to make future pull requests, I will try to raise the warning level/compiler strictness in GCC to provoke it into complaining more and more about some of the code.  With any luck this will help catch mistakes or typos in any z64 code.
