### PR TITLE
increased RDP command cache overflow tolerance

### DIFF
--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -55,7 +55,7 @@ int rdp_dump;
 #endif
 
 #define MAXCMD                  0x100000
-#define CMD_OVERFLOW_RESERVE    32
+#define CMD_OVERFLOW_RESERVE    4096
 static uint32_t rdp_cmd_data[MAXCMD + CMD_OVERFLOW_RESERVE];
 static volatile int rdp_cmd_ptr = 0;
 static volatile int rdp_cmd_cur = 0;


### PR DESCRIPTION
Honestly, I am more impatient with getting rid of these errors from spamming my console output, than I am with willingness to implement a recursive tolerance for infinitely large RDP command lists like angrylion's new code does, either in my fork of his plugin or in this plugin.  Again, as time goes on and when I finally backport some variation of angrylion's solution I will finally have a preference for how to properly fix this issue at last.

Until then, this new reserve value of 1024 seems to cure all the console errors for Mario64, Zelda MM and Conker's BFD, or at least that's what current in-game testing shows.
