### PR TITLE
fixed rdp_load_block() crashing in Zelda Majora's Mask

### DIFF
--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -470,25 +470,26 @@ static void rdp_load_block(uint32_t w1, uint32_t w2)
   }
 
     if (dxt == 0) {
- // rglAssert(tb+width/4 <= 0x1000/4);
+     // rglAssert(tb + width/4 <= 0x1000/4);
         for (i = 0; i < width / 4; i++) {
-            tc[(tb+i)&0x3ff] = src[((tl * rdpTiWidth) / 4) + rdpTiAddress / 4 + sl + i];
+            tc[(tb + i) & 0x3FF] = src[(tl * rdpTiWidth)/4 + rdpTiAddress/4 + sl + i];
         }
     } else {
         int j = 0;
 
-     // rglAssert(tb+width/4 <= 0x1000/4);
+     // rglAssert(tb + width/4 <= 0x1000/4);
 
-        int swap = rdpTiles[tilenum].size == 3? 2 : 1;
+        int swap = (rdpTiles[tilenum].size == 3) ? 2 : 1;
 
         for (i = 0; i < width / 4; i += 2) {
+            size_t src_base;
             int t = j >> 11;
+            const size_t swap_mask = (t & 1) ? swap : 0;
 
-            tc[(((tb + i) + 0) ^ ((t & 1) ? swap : 0)) & 0x3FF] =
-                src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 0];
-            tc[(((tb + i) + 1) ^ ((t & 1) ? swap : 0)) & 0x3FF] =
-                src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 1];
+            src_base = rdpTiAddress/4 + (tl * rdpTiWidth)/4 + sl + i;
 
+            tc[((tb + i + 0) ^ swap_mask) & 0x3FF] = src[src_base + 0];
+            tc[((tb + i + 1) ^ swap_mask) & 0x3FF] = src[src_base + 1];
             j += dxt;
         }
     }

--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -487,6 +487,13 @@ static void rdp_load_block(uint32_t w1, uint32_t w2)
             const size_t swap_mask = (t & 1) ? swap : 0;
 
             src_base = rdpTiAddress/4 + (tl * rdpTiWidth)/4 + sl + i;
+            if (src_base + 1 > 0x007FFFFF / sizeof(src[0])) {
+                fprintf(stderr,
+                    "ERROR:  Block load address 0x%lX exceeds 8 MB DRAM.\n",
+                    src_base + 1 /* (If + 0 exceeds it, then so does + 1.) */
+                );
+                return; /* Fix me:  Was the address corrupt or intended? */
+            } /* If it was intended, remove this error to do a real fix. */
 
             tc[((tb + i + 0) ^ swap_mask) & 0x3FF] = src[src_base + 0];
             tc[((tb + i + 1) ^ swap_mask) & 0x3FF] = src[src_base + 1];

--- a/src/rdp.cpp
+++ b/src/rdp.cpp
@@ -469,34 +469,29 @@ static void rdp_load_block(uint32_t w1, uint32_t w2)
     width = 0x1000-tb*4;
   }
 
-  if (dxt != 0)
-	{
-		int j=0;
+    if (dxt == 0) {
+ // rglAssert(tb+width/4 <= 0x1000/4);
+        for (i = 0; i < width / 4; i++) {
+            tc[(tb+i)&0x3ff] = src[((tl * rdpTiWidth) / 4) + rdpTiAddress / 4 + sl + i];
+        }
+    } else {
+        int j = 0;
 
-    //rglAssert(tb+width/4 <= 0x1000/4);
+     // rglAssert(tb+width/4 <= 0x1000/4);
 
-    int swap = rdpTiles[tilenum].size == 3? 2 : 1;
+        int swap = rdpTiles[tilenum].size == 3? 2 : 1;
 
-		for (i=0; i < width / 4; i+=2)
-		{
-			int t = j >> 11;
+        for (i = 0; i < width / 4; i += 2) {
+            int t = j >> 11;
 
-      tc[(((tb+i) + 0)  ^ ((t & 1) ? swap : 0))&0x3ff] =
-        src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 0];
-      tc[(((tb+i) + 1) ^ ((t & 1) ? swap : 0))&0x3ff] =
-        src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 1];
-        
-			j += dxt;
-		}
-	}
-	else
-	{
-    //rglAssert(tb+width/4 <= 0x1000/4);
-		for (i=0; i < width / 4; i++)
-		{
-			tc[(tb+i)&0x3ff] = src[((tl * rdpTiWidth) / 4) + rdpTiAddress / 4 + sl + i];
-		}
-	}
+            tc[(((tb + i) + 0) ^ ((t & 1) ? swap : 0)) & 0x3FF] =
+                src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 0];
+            tc[(((tb + i) + 1) ^ ((t & 1) ? swap : 0)) & 0x3FF] =
+                src[rdpTiAddress / 4 + ((tl * rdpTiWidth) / 4) + sl + i + 1];
+
+            j += dxt;
+        }
+    }
 }
 
 static void rdp_load_tile(uint32_t w1, uint32_t w2)


### PR DESCRIPTION
Fix GitHub issue https://github.com/purplemarshmallow/z64/issues/27.

Depending on **why** the address of 0x26C000 \* sizeof(uint32_t) occurred, this may be revisited in the future.  If the address is the result of another memory corruption bug by z64gl code causing overflow, we will instead look at fixing the cause of that.  On the other hand, maybe this address happens on actual N64 hardware--in which case, this PR should be followed up by more changes to remove this error message and commit tested changes to implement safely reading out values that exceed mapped DRAM addresses.

Until then this should be enough to fix some graphics crashes on both Windows and Linux--even if on Windows they're not noticeable enough to make the exe shut down.
